### PR TITLE
Make responses more API-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ Structured:
 In most cases (~90%), the two approaches agree in their overall results. They differ in the following situations:
 * Very large diffs -- when `timeout` is set to `True`, the StructuredEditTypes class is more likely to fall-back to a simple diff and miss some details as a result
 * Content moves -- the simplified library cannot detect moves
-* Changes vs. Inserts+Removes -- the simplified library does not distinguish between e.g., a template being changed vs. a template being removed and separate template being inserted
+* Changes vs. Inserts+Removes -- the simplified library does not distinguish between e.g., a template being changed vs. a template being removed and separate template being inserted 
+
+A good example of a diff where they vary in outputs is revision 1107840666 on English Wikipedia ([diff](https://en.wikipedia.org/w/index.php?diff=1107840666&oldid=1094519551&title=Blumenthal,_Saskatchewan&diffmode=source); [model output](https://wiki-topic.toolforge.org/diff-tagging?lang=en&revid=1107840666)).
 
 ## Language Coverage
 Almost everything in this library is language-agnostic and so works consistently for any language of Wikipedia.

--- a/mwedittypes/__init__.py
+++ b/mwedittypes/__init__.py
@@ -4,7 +4,7 @@ __title__ = "mwedittypes"
 __summary__ = "mwedittypes is a package that supports edit diffs and action detection for Wikipedia"
 __url__ = "https://github.com/geohci/edit-types"
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 __license__ = "MIT License"
 

--- a/mwedittypes/node_differ.py
+++ b/mwedittypes/node_differ.py
@@ -106,11 +106,11 @@ def get_node_diff(node_type, prev_wikitext='', curr_wikitext='', lang='en'):
             pr_name = None
             for a in prev_wc.attributes:
                 if a.name == 'name':
-                    pr_name = a.value
+                    pr_name = a.value.strip()
             cr_name = None
             for a in curr_wc.attributes:
                 if a.name == 'name':
-                    cr_name = a.value
+                    cr_name = a.value.strip()
             if pr_name != cr_name:
                 changes.append(('name', pr_name, cr_name))
 

--- a/mwedittypes/node_differ.py
+++ b/mwedittypes/node_differ.py
@@ -249,8 +249,8 @@ def get_node_diff(node_type, prev_wikitext='', curr_wikitext='', lang='en'):
 
         elif node_type == 'External Link':
             # separate between url and text (display) changes
-            pe_url = prev_wc.url if prev_wc else None
-            ce_url = curr_wc.url if curr_wc else None
+            pe_url = prev_wc.url.strip() if prev_wc else None
+            ce_url = curr_wc.url.strip() if curr_wc else None
             name = pe_url if pe_url else ce_url
             if pe_url != ce_url:
                 changes.append(('url', pe_url, ce_url))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '2.0.1'
+VERSION = '2.0.2'
 DESCRIPTION = 'Edit diffs and type detection for Wikipedia'
 LONG_DESCRIPTION = 'A package that allows edit diffs and type detection for Wikipedia.'
 


### PR DESCRIPTION
Cast mwparserfromhell objects in diff results to strings so doesn't throw errors when JSONified.