### PR TITLE
Section mismatch fix

### DIFF
--- a/mwedittypes/__init__.py
+++ b/mwedittypes/__init__.py
@@ -4,7 +4,7 @@ __title__ = "mwedittypes"
 __summary__ = "mwedittypes is a package that supports edit diffs and action detection for Wikipedia"
 __url__ = "https://github.com/geohci/edit-types"
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 
 __license__ = "MIT License"
 

--- a/mwedittypes/mwedittypes.py
+++ b/mwedittypes/mwedittypes.py
@@ -10,13 +10,12 @@ class StructuredEditTypes:
         self.curr_wikitext = curr_wikitext
         self.lang = lang
         self.timeout = timeout
-        self.debug = debug
         self.tree_diff = None
         self.actions = None
 
     def get_diff(self):
         self.tree_diff = get_diff(self.prev_wikitext, self.curr_wikitext, lang=self.lang,
-                                  timeout=self.timeout, debug=self.debug)
+                                  timeout=self.timeout)
         self.actions = get_diff_count(self.tree_diff, lang=self.lang)
         return self.actions
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
-VERSION = '2.0.2'
+VERSION = '2.1.0'
 DESCRIPTION = 'Edit diffs and type detection for Wikipedia'
 LONG_DESCRIPTION = 'A package that allows edit diffs and type detection for Wikipedia.'
 

--- a/tests/test_edittypes_summary.py
+++ b/tests/test_edittypes_summary.py
@@ -1,3 +1,5 @@
+import pytest
+
 from context import cjk_prev_wikitext, StructuredEditTypes, full_diff_to_simple, prev_wikitext, SimpleEditTypes
 
 # Text tests
@@ -46,7 +48,7 @@ def test_text_from_formatting():
     curr_wikitext = curr_wikitext.replace("'''Karl Josef Aigen'''",
                                           "''Karl Josef Aigen''",
                                           1)
-    expected_changes = {'Text Formatting': {'change': 2},
+    expected_changes = {'Text Formatting': {'change': 1},
                         'Section': {'change': 2}, 'Media': {'change': 1}}
     diff = SimpleEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert diff == expected_changes
@@ -67,12 +69,12 @@ def test_text_within_formatting():
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert full_diff_to_simple(full_diff) == expected_changes
 
-
+@pytest.mark.xfail(reason="Tree Differ can't currently detect simple shifts in text formatting start-stops.")
 def test_change_formatting_length():
     curr_wikitext = prev_wikitext.replace("'''Karl Josef Aigen''' (8 October 1684 – 22 October 1762) was a landscape painter, born at",
                                           "'''Karl Josef Aigen (8 October 1684 – 22 October 1762) was a landscape painter, born at'''",
                                           1)
-    expected_changes = {'Section': {'change': 1}, 'Text Formatting': {'change': 1}}
+    expected_changes = {'Section': {'change': 1}}
     diff = SimpleEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert diff == expected_changes
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
@@ -201,7 +203,7 @@ def test_link_within_formatting():
     curr_wikitext = prev_wikitext.replace("'''Karl Josef Aigen'''",
                                           "'''[[Karl Josef Aigen]]'''",
                                           1)
-    expected_changes = {'Wikilink': {'insert': 1}, 'Section': {'change': 1}, 'Text Formatting': {'change': 1}}
+    expected_changes = {'Wikilink': {'insert': 1}, 'Section': {'change': 1}}
     diff = SimpleEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert diff == expected_changes
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
@@ -316,4 +318,3 @@ def test_moved_section():
     assert diff == simple_expected_changes
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert full_diff_to_simple(full_diff) == full_expected_changes
-

--- a/tests/test_tree_differ.py
+++ b/tests/test_tree_differ.py
@@ -72,7 +72,8 @@ def test_remove_formatting():
     curr_wikitext = prev_wikitext.replace("'''Karl Josef Aigen'''",
                                           "Karl Josef Aigen",
                                           1)
-    expected_changes = [('remove', '0: Lede', 'Text Formatting')]
+    # two tf-spans removed; won't be reduced to a single block until the node differ
+    expected_changes = [('remove', '0: Lede', 'Text Formatting'), ('remove', '0: Lede', 'Text Formatting')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -105,10 +106,13 @@ table = """{| border="1" cellspacing="0" cellpadding="5"
 
 def test_insert_table():
     curr_wikitext = prev_wikitext + '\n' + table
+    # four tf-spans removed; won't be reduced to two blocks until the node differ
     expected_changes = [('insert', '4: ==External links==', 'Table'),
                         ('change', '4: ==External links==', 'Text'),
                         ('insert', '4: ==External links==', 'Wikilink'),
                         ('insert', '4: ==External links==', 'Wikilink'),
+                        ('insert', '4: ==External links==', 'Text Formatting'),
+                        ('insert', '4: ==External links==', 'Text Formatting'),
                         ('insert', '4: ==External links==', 'Text Formatting'),
                         ('insert', '4: ==External links==', 'Text Formatting')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
@@ -123,10 +127,12 @@ File:Lucas Cranach d.Ä. - Bildnis des Moritz Büchner.jpg|[[Lucas Cranach the E
 
 def test_insert_gallery():
     curr_wikitext = prev_wikitext + '\n' + gallery
+    # two tf-spans removed; won't be reduced to a single block until the node differ
     expected_changes = [('insert', '4: ==External links==', 'Gallery'),
                         ('change', '4: ==External links==', 'Text'),
                         ('insert', '4: ==External links==', 'Media'),
                         ('insert', '4: ==External links==', 'Wikilink'),
+                        ('insert', '4: ==External links==', 'Text Formatting'),
                         ('insert', '4: ==External links==', 'Text Formatting')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()


### PR DESCRIPTION
* Fix bug where text-formatting messes up the parsing of sections/headings and causes index errors
* In switch to skipping style tags when mwparserfromhell parses, logic to re-identify text formatting changes
* Remaining bug that a simple change in the span of a text formatting block that only crosses text elements
  will not trigger a corresponding text-formatting change for either differ (expected) but also won't trigger
  a section change in the StructuredEditTypes differ (unexpected).
* A huge speed-up for large trees due to caching of the leftmost property, which is static as long as the tree is static.
* Remove code for tracking node indices in the original wikitext -- most useful for debugging but not used
* Clarify some attribute names
* Store the mwparserfromhell node in the Node classes rather than just text and re-parsing whenever needed to reduce parsing time
* Bump version