### PR TITLE
Timeout bug with section alignment

### DIFF
--- a/mwedittypes/tree_differ.py
+++ b/mwedittypes/tree_differ.py
@@ -240,10 +240,10 @@ class Differ:
         """Remove all non-section nodes."""
         for n in PostOrderIter(t1.root):
             if n.ntype == 'Section':
-                n.children = []
+                n.children = n.children[:1] if n.children else []
         for n in PostOrderIter(t2.root):
             if n.ntype == 'Section':
-                n.children = []
+                n.children = n.children[:1] if n.children else []
 
     def prune_sections(self, t1, t2):
         """Prune nodes from any sections that align across revisions"""

--- a/mwedittypes/tree_differ.py
+++ b/mwedittypes/tree_differ.py
@@ -15,12 +15,6 @@ def get_diff(prev_wikitext, curr_wikitext, lang='en', timeout=False):
     d = Differ(prev_tree, curr_tree, timeout=timeout)
     diff = d.get_corresponding_nodes()
     result = diff.post_process(prev_tree.secname_to_text, curr_tree.secname_to_text, lang=lang)
-    # this helps the node differ know that the lede is also a new section
-    # otherwise depends on headings to track changes to sections
-    if not prev_wikitext:
-        result['prev-no-content'] = True
-    if not curr_wikitext:
-        result['curr-no-content'] = True
     return result
 
 
@@ -137,7 +131,8 @@ class WikitextTree:
         self.lang = lang
         self.root = OrderedNode('root', ntype="Article")
         self.secname_to_text = {}
-        self.wikitext_to_tree(wikitext)
+        if wikitext:
+            self.wikitext_to_tree(wikitext)
         self.key_roots = None
 
     def wikitext_to_tree(self, wikitext):
@@ -240,10 +235,10 @@ class Differ:
         """Remove all non-section nodes."""
         for n in PostOrderIter(t1.root):
             if n.ntype == 'Section':
-                n.children = n.children[:1] if n.children else []
+                n.children = []
         for n in PostOrderIter(t2.root):
             if n.ntype == 'Section':
-                n.children = n.children[:1] if n.children else []
+                n.children = []
 
     def prune_sections(self, t1, t2):
         """Prune nodes from any sections that align across revisions"""
@@ -302,12 +297,6 @@ class Differ:
         elif n1.ntype != n2.ntype:
             return self.nodetype_chg_cost
         elif n1.content_hash == n2.content_hash:
-            return 0
-        # if both sections, assert no cost (changes will be captured by headings)
-        # except we want to detect moves of sections
-        elif n1.ntype == 'Section':
-            if not n1.children and not n2.children:
-                return self.chg_cost
             return 0
         # otherwise, same node types and not the same, then change cost
         else:
@@ -399,11 +388,7 @@ class Differ:
                         transactions[i][j] = cc
 
     def get_corresponding_nodes(self):
-        """Explain transactions.
-
-        Skip 'Section' operations as they aren't real nodes and
-        any changes to them will be captured via Headings etc.
-        """
+        """Explain transactions."""
         if self.transactions:
             transactions = self.transactions[len(self.t1) - 1][len(self.t2) - 1]
             remove = []
@@ -412,18 +397,14 @@ class Differ:
             for i in range(0, len(transactions)):
                 if transactions[i][0] is None:
                     ins_node = self.t2[transactions[i][1]]
-                    # this second clause allows us to later detect moved sections
-                    if ins_node.ntype != 'Section' or not ins_node.children:
-                        insert.append(ins_node)
+                    insert.append(ins_node)
                 elif transactions[i][1] is None:
                     rem_node = self.t1[transactions[i][0]]
-                    if rem_node.ntype != 'Section' or not rem_node.children:
-                        remove.append(rem_node)
+                    remove.append(rem_node)
                 else:
                     prev_node = self.t1[transactions[i][0]]
                     curr_node = self.t2[transactions[i][1]]
-                    if prev_node.ntype != 'Section' or not prev_node.children:
-                        change.append((prev_node, curr_node))
+                    change.append((prev_node, curr_node))
             diff = {'remove': remove, 'insert': insert, 'change': change}
             self.detect_moves(diff)
             return Diff(nodes_removed=diff['remove'], nodes_inserted=diff['insert'],
@@ -565,7 +546,7 @@ class Diff:
         removed = []
         # removed sections map to null in current; inserted sections map to null in previous
         for n in self.remove:
-            if n['type'] == 'Heading':
+            if n['type'] == 'Section':
                 for i, s in enumerate(prev):
                     if s == n['section']:
                         removed.append(i)
@@ -573,9 +554,10 @@ class Diff:
         for idx in sorted(removed, reverse=True):
             p_to_c[prev[idx]] = None
             prev.pop(idx)
+
         inserted = []
         for n in self.insert:
-            if n['type'] == 'Heading':
+            if n['type'] == 'Section':
                 for i, s in enumerate(curr):
                     if s == n['section']:
                         inserted.append(i)
@@ -584,12 +566,13 @@ class Diff:
             c_to_p[curr[idx]] = None
             curr.pop(idx)
 
+
         # changes happen in place so don't effect structure of doc and can be ignored
         # for moved sections, reorder mapping so they are aligned again for dumping
         for c in self.move:
             pn = c['prev']
             cn = c['curr']
-            if pn['type'] == 'Heading':
+            if pn['type'] == 'Section':
                 prev_idx = None
                 curr_idx = None
                 for i, s in enumerate(prev):

--- a/mwedittypes/utils.py
+++ b/mwedittypes/utils.py
@@ -91,7 +91,7 @@ def extract_text(mwnode, lang='en'):
         return mwnode.contents.strip_code(collapse=False)
     elif ntype == 'Text Formatting':
         return ''.join(extract_text(mwn) for mwn in mwnode.contents.nodes)
-    # Heading, Template, Comment, Argument, Category, Media, References, URLs without display text
+    # Article, Section, Heading, Template, Comment, Argument, Category, Media, References, URLs without display text
     # Tags not listed here (div, gallery, etc.) that almost never have true text content and can be super messy
     # Table elements (they duplicate the text if included)
     else:

--- a/tests/test_edittypes_summary.py
+++ b/tests/test_edittypes_summary.py
@@ -69,12 +69,12 @@ def test_text_within_formatting():
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert full_diff_to_simple(full_diff) == expected_changes
 
-@pytest.mark.xfail(reason="Tree Differ can't currently detect simple shifts in text formatting start-stops.")
+@pytest.mark.xfail(reason="Differs can't currently detect simple shifts in text formatting start-stops.")
 def test_change_formatting_length():
     curr_wikitext = prev_wikitext.replace("'''Karl Josef Aigen''' (8 October 1684 – 22 October 1762) was a landscape painter, born at",
                                           "'''Karl Josef Aigen (8 October 1684 – 22 October 1762) was a landscape painter, born at'''",
                                           1)
-    expected_changes = {'Section': {'change': 1}}
+    expected_changes = {'Section': {'change': 1}, 'Text Formatting': {'change': 1}}
     diff = SimpleEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert diff == expected_changes
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
@@ -299,11 +299,15 @@ def test_complicated_sections():
     curr_wikitext = curr_wikitext.replace("[[Category:Artists from Olomouc]]",
                                           "[[Category:Artists in Olomouc]]",
                                           1)
-    expected_changes = {'Heading': {'insert': 1}, 'Category': {'change': 1}, 'Section': {'insert': 1, 'change': 2}}
+    simple_expected_changes = {'Heading': {'insert': 1}, 'Category': {'change': 1},
+                                   'Section': {'insert': 1, 'change': 2}}
     diff = SimpleEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
-    assert diff == expected_changes
+    assert diff == simple_expected_changes
+    # NOTE: simple expected changes are a bit more realistic but this is acceptable
+    structured_expected_changes = {'Heading': {'insert': 1}, 'Category': {'change': 1},
+                        'Section': {'insert': 2, 'change': 1, 'remove': 1}}
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
-    assert full_diff_to_simple(full_diff) == expected_changes
+    assert full_diff_to_simple(full_diff) == structured_expected_changes
 
 
 def test_moved_section():
@@ -313,7 +317,7 @@ def test_moved_section():
         "\n\n==References==\n{{reflist}}\n\n===Works===\nThe [[Österreichische Galerie Belvedere|Gallery of the Belvedere]] in Vienna has two works by him, both scenes with figures.<ref>{{Bryan (3rd edition)|title=Aigen, Karl |volume=1}}</ref>",
         1)
     simple_expected_changes = {}
-    full_expected_changes = {'Section':{'move':1, 'change':2}}
+    full_expected_changes = {'Section':{'move':1}}
     diff = SimpleEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()
     assert diff == simple_expected_changes
     full_diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en').get_diff()

--- a/tests/test_tree_differ.py
+++ b/tests/test_tree_differ.py
@@ -31,7 +31,8 @@ def test_insert_category():
     curr_wikitext = prev_wikitext.replace('[[Category:Artists from Olomouc]]\n',
                                           '[[Category:Artists from Olomouc]]\n[[Category:TEST CATEGORY]]',
                                           1)
-    expected_changes = [('insert', '4: ==External links==', 'Category')]
+    expected_changes = [('insert', '4: ==External links==', 'Category'),
+                        ('change', '4: ==External links==', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -41,7 +42,8 @@ def test_insert_link():
     curr_wikitext = prev_wikitext.replace('He was a pupil of the Olomouc painter',
                                           'He was a [[pupil]] of the Olomouc painter',
                                           1)
-    expected_changes = [('insert', '1: ==Life==', 'Wikilink')]
+    expected_changes = [('insert', '1: ==Life==', 'Wikilink'),
+                        ('change', '1: ==Life==', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -52,7 +54,9 @@ def test_move_template():
                                           '',
                                           1)
     curr_wikitext = '{{Austria-painter-stub}}' + curr_wikitext
-    expected_changes = [('move', '4: ==External links==', 'Template')]
+    expected_changes = [('move', '4: ==External links==', 'Template'),
+                        ('change', '4: ==External links==', 'Section'),
+                        ('change', '0: Lede', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -62,7 +66,8 @@ def test_change_heading():
     curr_wikitext = prev_wikitext.replace('===Works===',
                                           '===NotWorks===',
                                           1)
-    expected_changes = [('change', '2: ===Works===', 'Heading')]
+    expected_changes = [('change', '2: ===Works===', 'Heading'),
+                        ('change', '2: ===Works===', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -73,7 +78,8 @@ def test_remove_formatting():
                                           "Karl Josef Aigen",
                                           1)
     # two tf-spans removed; won't be reduced to a single block until the node differ
-    expected_changes = [('remove', '0: Lede', 'Text Formatting'), ('remove', '0: Lede', 'Text Formatting')]
+    expected_changes = [('remove', '0: Lede', 'Text Formatting'), ('remove', '0: Lede', 'Text Formatting'),
+                        ('change', '0: Lede', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -114,7 +120,8 @@ def test_insert_table():
                         ('insert', '4: ==External links==', 'Text Formatting'),
                         ('insert', '4: ==External links==', 'Text Formatting'),
                         ('insert', '4: ==External links==', 'Text Formatting'),
-                        ('insert', '4: ==External links==', 'Text Formatting')]
+                        ('insert', '4: ==External links==', 'Text Formatting'),
+                        ('change', '4: ==External links==', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -133,7 +140,8 @@ def test_insert_gallery():
                         ('insert', '4: ==External links==', 'Media'),
                         ('insert', '4: ==External links==', 'Wikilink'),
                         ('insert', '4: ==External links==', 'Text Formatting'),
-                        ('insert', '4: ==External links==', 'Text Formatting')]
+                        ('insert', '4: ==External links==', 'Text Formatting'),
+                        ('change', '4: ==External links==', 'Section')]
     diff = StructuredEditTypes(prev_wikitext, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)
@@ -142,7 +150,8 @@ def test_insert_gallery():
 def test_table_change():
     curr_wikitext = table.replace('general election', 'gen elec', 1)
     expected_changes = [('change', '0: Lede', 'Wikilink'),
-                        ('change', '0: Lede', 'Table')]
+                        ('change', '0: Lede', 'Table'),
+                        ('change', '0: Lede', 'Section')]
     diff = StructuredEditTypes(table, curr_wikitext, lang='en')
     diff.get_diff()
     check_change_counts(diff.tree_diff, expected_changes)


### PR DESCRIPTION
simple fix to prevent section pruning when timeout set to True to messing up section alignment dictionary when sections are inserted/removed